### PR TITLE
Defect Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <log4j2.version>2.25.1</log4j2.version>
+        <atscale.gatling.core.version>1.3</atscale.gatling.core.version>
     </properties>
     <build>
         <sourceDirectory>src/main</sourceDirectory>
@@ -54,7 +55,13 @@
                 <artifactId>gatling-maven-plugin</artifactId>
                 <version>${gatling-maven-plugin.version}</version>
                 <configuration>
-                    <!-- Enterprise Cloud (https://cloud.gatling.io/) configuration reference: https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#running-your-simulations-on-gatling-enterprise-cloud -->
+                    <!-- Need the following to get the gatling.runDescription and gatling.simulationClass properties to pass through so Gatling Highcharts can use the system property in the Report-->
+                    <jvmArgs>
+                        <jvmArg>-Xms2G</jvmArg>
+                        <jvmArg>-Xmx8G</jvmArg>
+                        <jvmArg>-Dgatling.runDescription=${gatling.runDescription}</jvmArg>
+                        <jvmArg>-Dgatling.simulationClass=${gatling.simulationClass}</jvmArg>
+                    </jvmArgs>
                 </configuration>
             </plugin>
             <!-- support for Scala -->
@@ -243,7 +250,7 @@
         <dependency>
             <groupId>com.atscale.gatling</groupId>
             <artifactId>atscale-gatling-core</artifactId>
-            <version>1.2</version>
+            <version>${atscale.gatling.core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
Updates for version 1.3 fixes pass through such that when we call task.setRunDescription('Desc') that value shows up on the Gatling HMTL report.   Also moves setting of heap size to the pom.xml as this proved reliable after refactoring the ProcessBuilder in the executors.